### PR TITLE
Fix phone normalization not being applied to PhoneOnlyMatcher

### DIFF
--- a/CRM/Xcm/DataNormaliser.php
+++ b/CRM/Xcm/DataNormaliser.php
@@ -59,6 +59,25 @@ class CRM_Xcm_DataNormaliser {
     if (!empty($data['birth_date'])) {
       $data['birth_date'] = date('Y-m-d', strtotime($data['birth_date']));
     }
+
+    if (!empty($data['phone']) && empty($data['phone_numeric'])) {
+      $phone = $data['phone'];
+      // use com.cividesk.normalize to normalize phone numbers prior to matching
+      // this is necessary if prefixing with +[country_code] is enabled, otherwise
+      // no incoming phone numbers without the prefix will match
+      if (method_exists('CRM_Utils_Normalize', 'normalize_phone')) {
+        $normalized_phone = [
+          'phone_type_id' => 1,
+          'phone' => $data['phone'],
+        ];
+        $normalizer = new CRM_Utils_Normalize();
+        $normalizer->normalize_phone($normalized_phone);
+        $phone = $normalized_phone['phone'];
+      }
+
+      // strip non-numeric characters
+      $data['phone_numeric'] = preg_replace('#[^0-9]#', '', $phone);
+    }
   }
 
   /**

--- a/CRM/Xcm/Matcher/PhoneMatcher.php
+++ b/CRM/Xcm/Matcher/PhoneMatcher.php
@@ -51,25 +51,9 @@ class CRM_Xcm_Matcher_PhoneMatcher extends CRM_Xcm_MatchingRule {
       }
     }
 
-    // use com.cividesk.normalize to normalize phone numbers prior to matching
-    // this is necessary if prefixing with +[country_code] is enabled, otherwise
-    // no incoming phone numbers without the prefix will match
-    if (method_exists('CRM_Utils_Normalize', 'normalize_phone')) {
-      // all we want is the normalized phone number, so make a copy first
-      $normalized_phone = $contact_data;
-      $normalized_phone['phone_type_id'] = 1; // use a dummy value
-      $normalizer = new CRM_Utils_Normalize();
-      $normalizer->normalize_phone($normalized_phone);
-      // strip non-numeric characters
-      $phone_numeric = preg_replace('#[^0-9]#', '', $normalized_phone['phone']);
-    } else {
-      // strip non-numeric characters
-      $phone_numeric = preg_replace('#[^0-9]#', '', $contact_data['phone']);
-    }
-
     // find phones
     $phone_query = $this->restrictions;
-    $phone_query['phone_numeric'] = $phone_numeric;
+    $phone_query['phone_numeric'] = $contact_data['phone_numeric'];
     $phone_query['return'] = 'contact_id';
     $phone_query['option.limit'] = 0;
     $phones_found = civicrm_api3('Phone', 'get', $phone_query);

--- a/CRM/Xcm/Matcher/PhoneOnlyMatcher.php
+++ b/CRM/Xcm/Matcher/PhoneOnlyMatcher.php
@@ -20,7 +20,7 @@
 class CRM_Xcm_Matcher_PhoneOnlyMatcher extends CRM_Xcm_Matcher_SingleAttributeMatcher {
 
   function __construct() {
-    parent::__construct('phone', 'Phone');
+    parent::__construct('phone_numeric', 'Phone');
   }
 
 }

--- a/CRM/Xcm/Matcher/SingleAttributeMatcher.php
+++ b/CRM/Xcm/Matcher/SingleAttributeMatcher.php
@@ -42,7 +42,7 @@ class CRM_Xcm_Matcher_SingleAttributeMatcher extends CRM_Xcm_MatchingRule {
       $this->fields = array(
         'first_name',
         'last_name',
-        'phone',
+        'phone_numeric',
         'email',
         'street_address',
         'postal_code',

--- a/tests/phpunit/CRM/Xcm/PhoneTest.php
+++ b/tests/phpunit/CRM/Xcm/PhoneTest.php
@@ -1,0 +1,63 @@
+<?php
+/*-------------------------------------------------------+
+| Extended Contact Matcher XCM                           |
+| Copyright (C) 2018 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+use CRM_Xcm_ExtensionUtil as E;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Test phone-related matching and handling
+ *
+ * @group headless
+ */
+class CRM_Xcm_PhoneTest extends CRM_Xcm_TestBase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  public function testPhoneNumeric() {
+    // set up our test scenario
+    $this->setXCMOption('fill_details', ['phone']);
+    $test_contact = $this->createContactWithRandomEmail([
+      'first_name' => 'John',
+      'last_name'  => 'Doe',
+    ]);
+    $this->setXCMOption(
+      'default_location_type',
+      $this->assertAPI3(
+        'LocationType',
+        'get',
+        ['is_default' => 1]
+      )
+    );
+    $this->assertAPI3('Phone', 'create', [
+      'contact_id' => $test_contact['id'],
+      'phone'      => '+43 680 1337199',
+    ]);
+
+    $this->setXCMRules(['CRM_Xcm_Matcher_PhoneLastnameMatcher']);
+    // lookup using a slightly different format
+    $this->assertXCMLookup([
+      'first_name'       => 'John',
+      'last_name'        => 'Doe',
+      'phone'            => '+43 680 133 71 99',
+    ], $test_contact['id']);
+
+    // repeat using phone-only matcher
+    $this->setXCMRules(['CRM_Xcm_Matcher_PhoneOnlyMatcher']);
+    $this->assertXCMLookup([
+      'phone'            => '+43 680 1 337 19 9',
+    ], $test_contact['id']);
+  }
+
+}


### PR DESCRIPTION
This fixes an issue where the phone normalization is not applied to the PhoneOnlyMatcher, meaning phone numbers in different formats would not be matched. The code was refactored slightly to move the normalization to a more appropriate component.