### PR TITLE
Added possibility for secondary phone

### DIFF
--- a/CRM/Xcm/Configuration.php
+++ b/CRM/Xcm/Configuration.php
@@ -345,6 +345,22 @@ class CRM_Xcm_Configuration {
     return (int) CRM_Utils_Array::value('default_location_type', $options);
   }
 
+  /**
+   * Get primary phone type
+   */
+  public function primaryPhoneType() {
+    $options = $this->getOptions();
+    return (int) CRM_Utils_Array::value('primary_phone_type', $options);
+  }
+
+  /**
+   * Get secondary phone type
+   */
+  public function secondaryPhoneType() {
+    $options = $this->getOptions();
+    return (int) CRM_Utils_Array::value('secondary_phone_type', $options);
+  }
+
 
   /**
    * Get location type to be used for new addresses

--- a/CRM/Xcm/Form/Settings.php
+++ b/CRM/Xcm/Form/Settings.php
@@ -67,6 +67,7 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
 
 
     $locationTypes = $this->getLocationTypes();
+    $phoneTypes = $this->getPhoneTypes();
 
     // add general options
     $this->addElement('select',
@@ -80,7 +81,18 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
                       E::ts('Default Location Type'),
                       $locationTypes,
                       array('class' => 'crm-select2 huge'));
-
+    $this->add('select',
+                      'primary_phone_type',
+                      E::ts('Primary Phone Type'),
+                      $phoneTypes,
+                      true,
+                      array('class' => 'crm-select2 huge'));
+    $this->add('select',
+                      'secondary_phone_type',
+                      E::ts('Secondary Phone Type'),
+                      $phoneTypes,
+                      false,
+                      array('class' => 'crm-select2 huge', 'placeholder' => E::ts('Secondary phone not used')));
     $this->addElement('select',
                       'fill_fields',
                       E::ts('Fill Fields'),
@@ -333,6 +345,8 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
       'override_details'           => CRM_Utils_Array::value('override_details', $values),
       'override_details_primary'   => CRM_Utils_Array::value('override_details_primary', $values),
       'default_location_type'      => CRM_Utils_Array::value('default_location_type', $values),
+      'primary_phone_type'         => CRM_Utils_Array::value('primary_phone_type', $values),
+      'secondary_phone_type'       => CRM_Utils_Array::value('secondary_phone_type', $values),
       'picker'                     => CRM_Utils_Array::value('picker', $values),
       'duplicates_activity'        => CRM_Utils_Array::value('duplicates_activity', $values),
       'duplicates_subject'         => CRM_Utils_Array::value('duplicates_subject', $values),
@@ -406,6 +420,15 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
     $result = civicrm_api3('LocationType', 'get', array('is_active' => 1));
     foreach ($result['values'] as $type) {
       $types[$type['id']] = $type['display_name'];
+    }
+    return $types;
+  }
+
+  protected function getPhoneTypes() {
+    $types = array();
+    $result = civicrm_api3('OptionValue', 'get', array('is_active' => 1, 'option_group_id' => 'phone_type', 'option.limit' => 0));
+    foreach ($result['values'] as $type) {
+      $types[$type['value']] = $type['label'];
     }
     return $types;
   }

--- a/CRM/Xcm/Tools.php
+++ b/CRM/Xcm/Tools.php
@@ -44,10 +44,13 @@ class CRM_Xcm_Tools {
 
   /**
    * Generate a list of field labels for the given diff
+   *
+   * @param array
+   * @param \CRM_Xcm_Configuration $config
    */
-  public static function getFieldLabels($differing_attributes) {
+  public static function getFieldLabels($differing_attributes, CRM_Xcm_Configuration $config) {
     $field_labels = array();
-    $all_labels = self::getKnownFieldLabels();
+    $all_labels = self::getKnownFieldLabels($config);
     foreach ($differing_attributes as $field_name) {
       if (isset($all_labels[$field_name])) {
         $field_labels[$field_name] = $all_labels[$field_name];
@@ -60,25 +63,50 @@ class CRM_Xcm_Tools {
 
   /**
    * return all field labels
+   *
+   * @param \CRM_Xcm_Configuration $config
    */
-  public static function getKnownFieldLabels() {
-    return array(
-      'first_name'             => ts('First Name'),
-      'last_name'              => ts('Last Name'),
-      'middle_name'            => ts('Middle Name'),
-      'prefix_id'              => ts('Prefix'),
-      'suffix_id'              => ts('Suffix'),
-      'phone'                  => ts('Phone'),
-      'email'                  => ts('Email'),
-      'street_address'         => ts('Street Address'),
-      'city'                   => ts('City'),
-      'country_id'             => ts('Country'),
-      'state_province_id'      => ts('State/Province'),
-      'postal_code'            => ts('Postal Code'),
-      'supplemental_address_1' => ts('Supplemental Address 1'),
-      'supplemental_address_2' => ts('Supplemental Address 2'),
-      'supplemental_address_3' => ts('Supplemental Address 3')
-    );
+  public static function getKnownFieldLabels(CRM_Xcm_Configuration $config) {
+    static $data = null;
+    if (!$data) {
+      $data = [
+        'first_name' => ts('First Name'),
+        'last_name' => ts('Last Name'),
+        'middle_name' => ts('Middle Name'),
+        'prefix_id' => ts('Prefix'),
+        'suffix_id' => ts('Suffix'),
+        'email' => ts('Email'),
+        'street_address' => ts('Street Address'),
+        'city' => ts('City'),
+        'country_id' => ts('Country'),
+        'state_province_id' => ts('State/Province'),
+        'postal_code' => ts('Postal Code'),
+        'supplemental_address_1' => ts('Supplemental Address 1'),
+        'supplemental_address_2' => ts('Supplemental Address 2'),
+        'supplemental_address_3' => ts('Supplemental Address 3')
+      ];
+      try {
+        $data['phone'] = civicrm_api3('OptionValue', 'getvalue', [
+          'return' => 'label',
+          'option_group_id' => 'phone_type',
+          'value' => $config->primaryPhoneType()
+        ]);
+      } catch (CiviCRM_API3_Exception $e) {
+        $data['phone'] = ts('Phone');
+      }
+      if ($config->secondaryPhoneType()) {
+        try {
+          $data['phone2'] = civicrm_api3('OptionValue', 'getvalue', [
+            'return' => 'label',
+            'option_group_id' => 'phone_type',
+            'value' => $config->secondaryPhoneType()
+          ]);
+        } catch (CiviCRM_API3_Exception $e) {
+          $data['phone2'] = ts('Phone 2');
+        }
+      }
+    }
+    return $data;
   }
 
   /**

--- a/Civi/Xcm/ActionProvider/Action/ContactGetOrCreate.php
+++ b/Civi/Xcm/ActionProvider/Action/ContactGetOrCreate.php
@@ -63,7 +63,8 @@ class ContactGetOrCreate extends AbstractAction {
 
         // detail fields
         new Specification('email', 'String', E::ts('Email'), false, null, null, null, false),
-        new Specification('phone', 'String', E::ts('Phone'), false, null, null, null, false),
+        new Specification('phone', 'String', E::ts('Primary Phone'), false, null, null, null, false),
+        new Specification('phone2', 'String', E::ts('Secondary Phone'), false, null, null, null, false),
         new Specification('website', 'String', E::ts('Website'), false, null, null, null, false),
         new Specification('name', 'String', E::ts('IM Handle'), false, null, null, null, false),
         new Specification('location_type_id', 'String', E::ts('Location Type ID'), false, null, null, null, false),

--- a/templates/CRM/Xcm/Form/Settings.hlp
+++ b/templates/CRM/Xcm/Form/Settings.hlp
@@ -48,6 +48,12 @@
   <p>{ts domain="de.systopia.xcm"}The location type is used for newly created addresses, emails, phones, and websites.{/ts}</p>
 {/htxt}
 
+{htxt id='id-phone-type'}
+  <p>{ts domain="de.systopia.xcm"}The phone type is used for newly created phone numbers.{/ts}</p>
+  <p>{ts domain="de.systopia.xcm"}There are two numbers possible and therefor two phone types.{/ts}</p>
+  <p>{ts domain="de.systopia.xcm"}If no secondary phone type is explicitly submitted then the second phone is not used.{/ts}</p>
+{/htxt}
+
 {htxt id='id-diff-activity'}
   <p>{ts domain="de.systopia.xcm"}This feature enables you to track and process all submitted data when a contact has been identified - but not changed.{/ts}</p>
   <p>{ts domain="de.systopia.xcm"}The activity will contain an overview of the differing attributes for contact, and will be linked to that contact.{/ts}</p>

--- a/templates/CRM/Xcm/Form/Settings.tpl
+++ b/templates/CRM/Xcm/Form/Settings.tpl
@@ -48,6 +48,18 @@
     <div class="clear"></div>
   </div>
 
+  <div class="crm-section">
+    <div class="label">{$form.primary_phone_type.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.xcm"}Primary Phone Type{/ts}", {literal}{"id":"id-phone-type","file":"CRM\/Xcm\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.xcm"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+    <div class="content">{$form.primary_phone_type.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
+    <div class="label">{$form.secondary_phone_type.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.xcm"}Secondary Phone Type{/ts}", {literal}{"id":"id-phone-type","file":"CRM\/Xcm\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.xcm"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+    <div class="content">{$form.secondary_phone_type.html}</div>
+    <div class="clear"></div>
+  </div>
+
 </div>
 
 <div>


### PR DESCRIPTION
# Before

Only one phone number could be created by the XCM.

# After

Possible to set a secondary phone number with XCM. 

In the option screen there is no two additional options for configuring the phone type of the primary and the secondary phone:

![Screenshot from 2020-02-24 11-26-42](https://user-images.githubusercontent.com/4126292/75145185-c5491280-56f8-11ea-9ac9-fbebba438592.png)


# Use case

I had a use case where a land line and a mobile came through and we had to compare both phone numbers. This change makes this possible. 