### PR TITLE
updated the way settings are handled

### DIFF
--- a/CRM/Xcm/Configuration.php
+++ b/CRM/Xcm/Configuration.php
@@ -104,7 +104,7 @@ class CRM_Xcm_Configuration {
    */
   protected static function &getAllProfiles() {
     if (self::$_all_profiles === NULL) {
-      self::$_all_profiles = CRM_Core_BAO_Setting::getItem('de.systopia.xcm', 'xcm_config_profiles');
+      self::$_all_profiles = Civi::settings()->get('xcm_config_profiles');
       if (!is_array(self::$_all_profiles) || empty(self::$_all_profiles)) {
         self::$_all_profiles = array('default' => array());
       }
@@ -117,7 +117,7 @@ class CRM_Xcm_Configuration {
    */
   public static function storeAllProfiles() {
     if (is_array(self::$_all_profiles)) {
-      CRM_Core_BAO_Setting::setItem(self::$_all_profiles, 'de.systopia.xcm', 'xcm_config_profiles');
+      Civi::settings()->set('xcm_config_profiles', self::$_all_profiles);
     }
   }
 

--- a/CRM/Xcm/Upgrader.php
+++ b/CRM/Xcm/Upgrader.php
@@ -95,4 +95,11 @@ class CRM_Xcm_Upgrader extends CRM_Xcm_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_0171() {
+    // Change the way how settings are stored.
+    $_all_profiles = CRM_Core_BAO_Setting::getItem('de.systopia.xcm', 'xcm_config_profiles');
+    Civi::settings()->set('xcm_config_profiles', $_all_profiles);
+    return TRUE;
+  }
+
 }


### PR DESCRIPTION
# Before

Settings are stored with a deprecated method. Causing the unit tests to fail.

# After

Settings are stored with the `Civi::settings()->set` method. 
This PR also includes an database upgrade function.