### PR TITLE
refactored implementation of action provider

### DIFF
--- a/CRM/Xcm/Form/Settings.php
+++ b/CRM/Xcm/Form/Settings.php
@@ -15,9 +15,6 @@
 
 require_once 'CRM/Core/Form.php';
 
-use Civi\ActionProvider\Parameter\Specification;
-use Civi\ActionProvider\Parameter\SpecificationBag;
-use Civi\ActionProvider\Utils\CustomField;
 use CRM_Xcm_ExtensionUtil as E;
 
 define('XCM_MAX_RULE_COUNT', 9);
@@ -530,35 +527,34 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
   /**
    * get a list of custom fields eligible for submission.
    * those are all custom fields that belong to a contact in general
-   *
-   * @return array
-   * @throws \Exception
    */
   public static function getCustomFields() {
-    $specs = array();
+    $custom_fields = array();
+
     $custom_group_query = civicrm_api3('CustomGroup', 'get', array(
       'extends'      => array('IN' => array('Contact', 'Individual', 'Organization', 'Household')),
       'is_active'    => 1,
       'option.limit' => 0,
       'is_multiple'  => 0,
-      'is_reserved'  => 0));
+      'is_reserved'  => 0,
+      'return'       => 'id'));
     $custom_group_ids   = array();
-    $custom_groups = array();
     foreach ($custom_group_query['values'] as $custom_group) {
       $custom_group_ids[] = (int) $custom_group['id'];
-      $custom_groups[$custom_group['id']] = $custom_group;
     }
 
     if (!empty($custom_group_ids)) {
       $custom_field_query = civicrm_api3('CustomField', 'get', array(
         'custom_group_id'  => array('IN' => $custom_group_ids),
         'is_active'        => 1,
-        'option.limit'     => 0));
+        'option.limit'     => 0,
+        'return'           => 'id,label'));
       foreach ($custom_field_query['values'] as $custom_field) {
-        $specs[] = CustomField::getSpecFromCustomField($custom_field, $custom_groups[$custom_field['custom_group_id']]['title'].': ', false);
+        $custom_fields["custom_{$custom_field['id']}"] = "{$custom_field['label']} [{$custom_field['id']}]";
       }
     }
-    return $specs;
+
+    return $custom_fields;
   }
 
   /**
@@ -567,29 +563,29 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
    */
   public static function getContactFields() {
     return array(
-      new Specification('display_name', 'String', E::ts("Display Name")),
-      new Specification('household_name', 'String', E::ts("Household Name")),
-      new Specification('organization_name', 'String', E::ts("Organization Name")),
-      new Specification('first_name', 'String', E::ts("First Name")),
-      new Specification('last_name', 'String', E::ts("Last Name")),
-      new Specification('middle_name', 'String', E::ts("Middle Name")),
-      new Specification('nick_name', 'String', E::ts("Nick Name")),
-      new Specification('legal_name', 'String', E::ts("Legal Name")),
-      new Specification('prefix_id', 'String', E::ts("Prefix")),
-      new Specification('suffix_id', 'String', E::ts("Suffix")),
-      new Specification('birth_date', 'String', E::ts("Birth Date")),
-      new Specification('gender_id', 'String', E::ts("Gender")),
-      new Specification('formal_title', 'String', E::ts("Formal Title")),
-      new Specification('job_title', 'String', E::ts("Job Title")),
-      new Specification('do_not_email', 'String', E::ts("Do not Email")),
-      new Specification('do_not_phone', 'String', E::ts("Do not Phone")),
-      new Specification('do_not_sms', 'String', E::ts("Do not SMS")),
-      new Specification('do_not_trade', 'String', E::ts("Do not Trade")),
-      new Specification('is_opt_out', 'String', E::ts("Opt-Out")),
-      new Specification('preferred_language', 'String', E::ts("Preferred Language")),
-      new Specification('preferred_communication_method', 'String', E::ts("Preferred Communication Method")),
-      new Specification('legal_identifier', 'String', E::ts("Legal Identifier")),
-      new Specification('external_identifier', 'String', E::ts("External Identifier")),
+      'display_name'                   => E::ts("Display Name"),
+      'household_name'                 => E::ts("Household Name"),
+      'organization_name'              => E::ts("Organization Name"),
+      'first_name'                     => E::ts("First Name"),
+      'last_name'                      => E::ts("Last Name"),
+      'middle_name'                    => E::ts("Middle Name"),
+      'nick_name'                      => E::ts("Nick Name"),
+      'legal_name'                     => E::ts("Legal Name"),
+      'prefix_id'                      => E::ts("Prefix"),
+      'suffix_id'                      => E::ts("Suffix"),
+      'birth_date'                     => E::ts("Birth Date"),
+      'gender_id'                      => E::ts("Gender"),
+      'formal_title'                   => E::ts("Formal Title"),
+      'job_title'                      => E::ts("Job Title"),
+      'do_not_email'                   => E::ts("Do not Email"),
+      'do_not_phone'                   => E::ts("Do not Phone"),
+      'do_not_sms'                     => E::ts("Do not SMS"),
+      'do_not_trade'                   => E::ts("Do not Trade"),
+      'is_opt_out'                     => E::ts("Opt-Out"),
+      'preferred_language'             => E::ts("Preferred Language"),
+      'preferred_communication_method' => E::ts("Preferred Communication Method"),
+      'legal_identifier'               => E::ts("Legal Identifier"),
+      'external_identifier'            => E::ts("External Identifier"),
     );
   }
 }

--- a/CRM/Xcm/Form/Settings.php
+++ b/CRM/Xcm/Form/Settings.php
@@ -15,6 +15,9 @@
 
 require_once 'CRM/Core/Form.php';
 
+use Civi\ActionProvider\Parameter\Specification;
+use Civi\ActionProvider\Parameter\SpecificationBag;
+use Civi\ActionProvider\Utils\CustomField;
 use CRM_Xcm_ExtensionUtil as E;
 
 define('XCM_MAX_RULE_COUNT', 9);
@@ -527,34 +530,35 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
   /**
    * get a list of custom fields eligible for submission.
    * those are all custom fields that belong to a contact in general
+   *
+   * @return array
+   * @throws \Exception
    */
   public static function getCustomFields() {
-    $custom_fields = array();
-
+    $specs = array();
     $custom_group_query = civicrm_api3('CustomGroup', 'get', array(
       'extends'      => array('IN' => array('Contact', 'Individual', 'Organization', 'Household')),
       'is_active'    => 1,
       'option.limit' => 0,
       'is_multiple'  => 0,
-      'is_reserved'  => 0,
-      'return'       => 'id'));
+      'is_reserved'  => 0));
     $custom_group_ids   = array();
+    $custom_groups = array();
     foreach ($custom_group_query['values'] as $custom_group) {
       $custom_group_ids[] = (int) $custom_group['id'];
+      $custom_groups[$custom_group['id']] = $custom_group;
     }
 
     if (!empty($custom_group_ids)) {
       $custom_field_query = civicrm_api3('CustomField', 'get', array(
         'custom_group_id'  => array('IN' => $custom_group_ids),
         'is_active'        => 1,
-        'option.limit'     => 0,
-        'return'           => 'id,label'));
+        'option.limit'     => 0));
       foreach ($custom_field_query['values'] as $custom_field) {
-        $custom_fields["custom_{$custom_field['id']}"] = "{$custom_field['label']} [{$custom_field['id']}]";
+        $specs[] = CustomField::getSpecFromCustomField($custom_field, $custom_groups[$custom_field['custom_group_id']]['title'].': ', false);
       }
     }
-
-    return $custom_fields;
+    return $specs;
   }
 
   /**
@@ -563,29 +567,29 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
    */
   public static function getContactFields() {
     return array(
-      'display_name'                   => E::ts("Display Name"),
-      'household_name'                 => E::ts("Household Name"),
-      'organization_name'              => E::ts("Organization Name"),
-      'first_name'                     => E::ts("First Name"),
-      'last_name'                      => E::ts("Last Name"),
-      'middle_name'                    => E::ts("Middle Name"),
-      'nick_name'                      => E::ts("Nick Name"),
-      'legal_name'                     => E::ts("Legal Name"),
-      'prefix_id'                      => E::ts("Prefix"),
-      'suffix_id'                      => E::ts("Suffix"),
-      'birth_date'                     => E::ts("Birth Date"),
-      'gender_id'                      => E::ts("Gender"),
-      'formal_title'                   => E::ts("Formal Title"),
-      'job_title'                      => E::ts("Job Title"),
-      'do_not_email'                   => E::ts("Do not Email"),
-      'do_not_phone'                   => E::ts("Do not Phone"),
-      'do_not_sms'                     => E::ts("Do not SMS"),
-      'do_not_trade'                   => E::ts("Do not Trade"),
-      'is_opt_out'                     => E::ts("Opt-Out"),
-      'preferred_language'             => E::ts("Preferred Language"),
-      'preferred_communication_method' => E::ts("Preferred Communication Method"),
-      'legal_identifier'               => E::ts("Legal Identifier"),
-      'external_identifier'            => E::ts("External Identifier"),
+      new Specification('display_name', 'String', E::ts("Display Name")),
+      new Specification('household_name', 'String', E::ts("Household Name")),
+      new Specification('organization_name', 'String', E::ts("Organization Name")),
+      new Specification('first_name', 'String', E::ts("First Name")),
+      new Specification('last_name', 'String', E::ts("Last Name")),
+      new Specification('middle_name', 'String', E::ts("Middle Name")),
+      new Specification('nick_name', 'String', E::ts("Nick Name")),
+      new Specification('legal_name', 'String', E::ts("Legal Name")),
+      new Specification('prefix_id', 'String', E::ts("Prefix")),
+      new Specification('suffix_id', 'String', E::ts("Suffix")),
+      new Specification('birth_date', 'String', E::ts("Birth Date")),
+      new Specification('gender_id', 'String', E::ts("Gender")),
+      new Specification('formal_title', 'String', E::ts("Formal Title")),
+      new Specification('job_title', 'String', E::ts("Job Title")),
+      new Specification('do_not_email', 'String', E::ts("Do not Email")),
+      new Specification('do_not_phone', 'String', E::ts("Do not Phone")),
+      new Specification('do_not_sms', 'String', E::ts("Do not SMS")),
+      new Specification('do_not_trade', 'String', E::ts("Do not Trade")),
+      new Specification('is_opt_out', 'String', E::ts("Opt-Out")),
+      new Specification('preferred_language', 'String', E::ts("Preferred Language")),
+      new Specification('preferred_communication_method', 'String', E::ts("Preferred Communication Method")),
+      new Specification('legal_identifier', 'String', E::ts("Legal Identifier")),
+      new Specification('external_identifier', 'String', E::ts("External Identifier")),
     );
   }
 }

--- a/Civi/Xcm/ActionProvider/Action/ContactGetOrCreate.php
+++ b/Civi/Xcm/ActionProvider/Action/ContactGetOrCreate.php
@@ -22,6 +22,7 @@ use \Civi\ActionProvider\Action\AbstractAction;
 use \Civi\ActionProvider\Parameter\ParameterBagInterface;
 use \Civi\ActionProvider\Parameter\Specification;
 use \Civi\ActionProvider\Parameter\SpecificationBag;
+use \Civi\ActionProvider\Utils\CustomField;
 
 class ContactGetOrCreate extends AbstractAction {
 
@@ -51,10 +52,11 @@ class ContactGetOrCreate extends AbstractAction {
   public function getParameterSpecification() {
     // add contact specs
     $contact_specs = [];
-    $contact_fields = CRM_Xcm_Form_Settings::getContactFields() + CRM_Xcm_Form_Settings::getCustomFields();
+    $contact_fields = CRM_Xcm_Form_Settings::getContactFields();
     foreach ($contact_fields as $contact_field_name => $contact_field_label) {
       $contact_specs[] = new Specification($contact_field_name, 'String', $contact_field_label, false, null, null, null, false);
     }
+    $contact_specs = array_merge($contact_specs, self::getCustomFields());
 
     return new SpecificationBag(array_merge($contact_specs, [
         // special fields
@@ -83,6 +85,39 @@ class ContactGetOrCreate extends AbstractAction {
         new Specification('country_id', 'String', E::ts('Country'), false, null, null, null, false),
         new Specification('is_billing', 'Integer', E::ts('Billing?'), false, null, null, null, false),
    ]));
+  }
+
+  /**
+   * Returns the custom fields as a Specification array.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private static function getCustomFields() {
+    $specs = array();
+    $custom_group_query = civicrm_api3('CustomGroup', 'get', array(
+      'extends'      => array('IN' => array('Contact', 'Individual', 'Organization', 'Household')),
+      'is_active'    => 1,
+      'option.limit' => 0,
+      'is_multiple'  => 0,
+      'is_reserved'  => 0));
+    $custom_group_ids   = array();
+    $custom_groups = array();
+    foreach ($custom_group_query['values'] as $custom_group) {
+      $custom_group_ids[] = (int) $custom_group['id'];
+      $custom_groups[$custom_group['id']] = $custom_group;
+    }
+
+    if (!empty($custom_group_ids)) {
+      $custom_field_query = civicrm_api3('CustomField', 'get', array(
+        'custom_group_id'  => array('IN' => $custom_group_ids),
+        'is_active'        => 1,
+        'option.limit'     => 0));
+      foreach ($custom_field_query['values'] as $custom_field) {
+        $specs[] = CustomField::getSpecFromCustomField($custom_field, $custom_groups[$custom_field['custom_group_id']]['title'].': ', false);
+      }
+    }
+    return $specs;
   }
 
   /**

--- a/Civi/Xcm/ActionProvider/Action/ContactGetOrCreate.php
+++ b/Civi/Xcm/ActionProvider/Action/ContactGetOrCreate.php
@@ -50,7 +50,12 @@ class ContactGetOrCreate extends AbstractAction {
    */
   public function getParameterSpecification() {
     // add contact specs
-    $contact_specs = array_merge(CRM_Xcm_Form_Settings::getContactFields(), CRM_Xcm_Form_Settings::getCustomFields());
+    $contact_specs = [];
+    $contact_fields = CRM_Xcm_Form_Settings::getContactFields() + CRM_Xcm_Form_Settings::getCustomFields();
+    foreach ($contact_fields as $contact_field_name => $contact_field_label) {
+      $contact_specs[] = new Specification($contact_field_name, 'String', $contact_field_label, false, null, null, null, false);
+    }
+
     return new SpecificationBag(array_merge($contact_specs, [
         // special fields
         new Specification('contact_type', 'String', E::ts('Contact Type'), false, 'Individual', null, ['Individual', 'Organization', 'Household'], false),
@@ -103,29 +108,16 @@ class ContactGetOrCreate extends AbstractAction {
    * @return void
    */
   protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
-    $apiParams = array();
-    foreach($this->getParameterSpecification() as $spec) {
-      if ($parameters->doesParameterExists($spec->getName())) {
-        if ($spec->getApiFieldName()) {
-          $apiParams[$spec->getApiFieldName()] = $parameters->getParameter($spec->getName());
-        } else {
-          $apiParams[$spec->getName()] = $parameters->getParameter($spec->getName());
-        }
-      } elseif ($spec->getApiFieldName() && $parameters->doesParameterExists($spec->getApiFieldName())) {
-        // Use above statement so that custom_1 still works.
-        $apiParams[$spec->getApiFieldName()] = $parameters->getParameter($spec->getApiFieldName());
-      }
-    }
-
+    $params = $parameters->toArray();
     // override if necessary
     foreach (['xcm_profile', 'contact_type'] as $field_name) {
-      if (empty($apiParams[$field_name])) {
-        $apiParams[$field_name] = $this->configuration->getParameter($field_name);
+      if (empty($params[$field_name])) {
+        $params[$field_name] = $this->configuration->getParameter($field_name);
       }
     }
 
     // execute
-    $result = \civicrm_api3('Contact', 'getorcreate', $apiParams);
+    $result = \civicrm_api3('Contact', 'getorcreate', $params);
     $output->setParameter('contact_id', $result['id']);
   }
 }


### PR DESCRIPTION
# Before

When I exported a form processor with the XCM action on it and I mapped a custom field it was exported as custom_3. Where 3 is the ID of the field. 

# After

When I export the form processor with the XCM action on it and I mapped a custom field it is exported as custom_Individual_data_Matricule 
Where Indvidual_data is the name of the custom group and Matricule the name of the custom field.
This way the configuration is consitent across all environments. 

# Remarks

This PR is backwards compatible. Meaning that existing form processors keeps working.
However when you edit an existing action the mapping of the custom field seems lost so you have to set it again. 
