### PR TITLE
Fix for #58

### DIFF
--- a/Civi/Xcm/ActionProvider/Action/ContactGetOrCreate.php
+++ b/Civi/Xcm/ActionProvider/Action/ContactGetOrCreate.php
@@ -115,7 +115,10 @@ class ContactGetOrCreate extends AbstractAction {
         'is_active'        => 1,
         'option.limit'     => 0));
       foreach ($custom_field_query['values'] as $custom_field) {
-        $specs[] = CustomField::getSpecFromCustomField($custom_field, $custom_groups[$custom_field['custom_group_id']]['title'].': ', false);
+        $spec = CustomField::getSpecFromCustomField($custom_field, $custom_groups[$custom_field['custom_group_id']]['title'].': ', false);
+        if ($spec) {
+          $specs[] = $spec;
+        }
       }
     }
     return $specs;


### PR DESCRIPTION
# Steps to reproduce

1. Install Form Processor and Action provider
2. Add a custom file field to a contact
3. Create a new form processor add the XCM action

## Before 

Configuration screen isn't shown

## After

Configuration screen is visible

## Technical details

The screen wasn't show because the action got an error trying to create a parameter for the custom field of type file.