### PR TITLE
Fix for issue #60

### DIFF
--- a/Civi/Xcm/ActionProvider/Action/ContactGetOrCreate.php
+++ b/Civi/Xcm/ActionProvider/Action/ContactGetOrCreate.php
@@ -85,6 +85,8 @@ class ContactGetOrCreate extends AbstractAction {
         new Specification('county_id', 'String', E::ts('County'), false, null, null, null, false),
         new Specification('country_id', 'String', E::ts('Country'), false, null, null, null, false),
         new Specification('is_billing', 'Integer', E::ts('Billing?'), false, null, null, null, false),
+
+        new Specification('source', 'String', E::ts('Source'), false, null, null, null, false),
    ]));
   }
 


### PR DESCRIPTION
# Before

Not able to set source parameter when creating a contact from the form processor

# After 

The source field could be used when creating a contact through xcm and the form processor.