### PR TITLE
Contact Update Report/Update and Diff activity

### DIFF
--- a/CRM/Xcm/Configuration.php
+++ b/CRM/Xcm/Configuration.php
@@ -332,6 +332,8 @@ class CRM_Xcm_Configuration {
       return 'i3val';
     } elseif ($handler == 'diff') {
       return 'diff';
+    } elseif ($handler == 'updated_diff') {
+      return 'updated_diff';
     } else {
       return 'none';
     }

--- a/CRM/Xcm/Form/Settings.php
+++ b/CRM/Xcm/Form/Settings.php
@@ -516,6 +516,7 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
     $diff_handlers = array();
     $diff_handlers['none'] = E::ts("Don't do anything");
     $diff_handlers['diff'] = E::ts("Diff Activity");
+    $diff_handlers['updated_diff'] = E::ts("Update and Difference Activity");
 
     if (function_exists('i3val_civicrm_install')) {
       $diff_handlers['i3val'] = E::ts("I3Val Handler");

--- a/CRM/Xcm/Form/Settings.php
+++ b/CRM/Xcm/Form/Settings.php
@@ -167,6 +167,11 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
                       E::ts('Activity Type'),
                       $this->getActivities(FALSE),
                       array('class' => 'crm-select2'));
+    $this->addElement('select',
+      'diff_activity_status',
+      E::ts('Activity Status'),
+      $this->getActivityStatuses(),
+      array('class' => 'crm-select2'));
 
     $this->addElement('text',
                       "diff_activity_subject",
@@ -352,6 +357,7 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
       'duplicates_subject'         => CRM_Utils_Array::value('duplicates_subject', $values),
       'diff_handler'               => CRM_Utils_Array::value('diff_handler', $values),
       'diff_activity'              => CRM_Utils_Array::value('diff_activity', $values),
+      'diff_activity_status'       => CRM_Utils_Array::value('diff_activity_status', $values),
       'diff_activity_subject'      => CRM_Utils_Array::value('diff_activity_subject', $values),
       'diff_processing'            => CRM_Utils_Array::value('diff_processing', $values),
       'diff_current_location_type' => CRM_Utils_Array::value('diff_current_location_type', $values),
@@ -515,8 +521,8 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
   protected function getDiffHandlers() {
     $diff_handlers = array();
     $diff_handlers['none'] = E::ts("Don't do anything");
-    $diff_handlers['diff'] = E::ts("Diff Activity");
-    $diff_handlers['updated_diff'] = E::ts("Update and Difference Activity");
+    $diff_handlers['diff'] = E::ts("Only changes requiring review (Diff Activity)");
+    $diff_handlers['updated_diff'] = E::ts("All changes (Difference and Update Activity)");
 
     if (function_exists('i3val_civicrm_install')) {
       $diff_handlers['i3val'] = E::ts("I3Val Handler");

--- a/CRM/Xcm/Form/Settings.php
+++ b/CRM/Xcm/Form/Settings.php
@@ -521,8 +521,8 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
   protected function getDiffHandlers() {
     $diff_handlers = array();
     $diff_handlers['none'] = E::ts("Don't do anything");
-    $diff_handlers['diff'] = E::ts("Only changes requiring review (Diff Activity)");
-    $diff_handlers['updated_diff'] = E::ts("All changes (Difference and Update Activity)");
+    $diff_handlers['diff'] = E::ts("Unresolved Differences");
+    $diff_handlers['updated_diff'] = E::ts("Contact Value Comparison");
 
     if (function_exists('i3val_civicrm_install')) {
       $diff_handlers['i3val'] = E::ts("I3Val Handler");

--- a/CRM/Xcm/MatchingEngine.php
+++ b/CRM/Xcm/MatchingEngine.php
@@ -1051,7 +1051,7 @@ class CRM_Xcm_MatchingEngine {
       $activity_data = array(
           'activity_type_id'   => $options['diff_activity'],
           'subject'            => $subject,
-          'status_id'          => $this->config->defaultActivityStatus(),
+          'status_id'          => !empty($options['diff_activity_status']) ? $options['diff_activity_status'] : $this->config->defaultActivityStatus(),
           'activity_date_time' => date("YmdHis"),
           'target_contact_id'  => (int) $contact['id'],
           'source_contact_id'  => $this->config->getCurrentUserID($contact['id']),

--- a/CRM/Xcm/MatchingEngine.php
+++ b/CRM/Xcm/MatchingEngine.php
@@ -342,11 +342,14 @@ class CRM_Xcm_MatchingEngine {
       // HANDLE DIFFERENCES
       switch ($diff_handler) {
         case 'diff':
+          $this->createDiffActivity($current_contact_data, $options, $options['diff_activity_subject'], $submitted_contact_data, $location_type_id);
+          break;
+        case 'updated_diff':
           $this->createDiffActivity($original_contact_data, $options, $options['diff_activity_subject'], $submitted_contact_data, $location_type_id);
           break;
 
         case 'i3val':
-          $this->createI3ValActivity($original_contact_data, $submitted_contact_data);
+          $this->createI3ValActivity($current_contact_data, $submitted_contact_data);
 
         default:
           break;

--- a/CRM/Xcm/MatchingEngine.php
+++ b/CRM/Xcm/MatchingEngine.php
@@ -259,6 +259,7 @@ class CRM_Xcm_MatchingEngine {
       // load contact
       $current_contact_data = $this->loadCurrentContactData($result['contact_id'], $submitted_contact_data);
       CRM_Xcm_DataNormaliser::normaliseData($current_contact_data);
+      $original_contact_data = $current_contact_data;
 
       // OVERRIDE CURRENT CONTACT DATA
       if (!empty($options['override_fields'])) {
@@ -341,11 +342,11 @@ class CRM_Xcm_MatchingEngine {
       // HANDLE DIFFERENCES
       switch ($diff_handler) {
         case 'diff':
-          $this->createDiffActivity($current_contact_data, $options, $options['diff_activity_subject'], $submitted_contact_data, $location_type_id);
+          $this->createDiffActivity($original_contact_data, $options, $options['diff_activity_subject'], $submitted_contact_data, $location_type_id);
           break;
 
         case 'i3val':
-          $this->createI3ValActivity($current_contact_data, $submitted_contact_data);
+          $this->createI3ValActivity($original_contact_data, $submitted_contact_data);
 
         default:
           break;

--- a/templates/CRM/Xcm/Form/Settings.hlp
+++ b/templates/CRM/Xcm/Form/Settings.hlp
@@ -57,7 +57,7 @@
 {htxt id='id-diff-activity'}
   <p>{ts domain="de.systopia.xcm"}This feature enables you to track and process all submitted data when a contact has been identified - but not changed.{/ts}</p>
   <p>{ts domain="de.systopia.xcm"}The activity will contain an overview of the differing attributes for contact, and will be linked to that contact.{/ts}</p>
-  <p>{ts domain="de.systopia.xcm"}The handler Update and Difference activity will also record the updated changes. Whlist the Diff Activity will only record the differences and you have to apply the changes manually.{/ts}</p>
+  <p>{ts domain="de.systopia.xcm"}The handler Contact Value Comparison will record all changes. Whlist the Unresolved Differences handler will only record the unresolved differences which need to be manually applied.{/ts}</p>
 {/htxt}
 
 {htxt id='id-override-details'}

--- a/templates/CRM/Xcm/Form/Settings.hlp
+++ b/templates/CRM/Xcm/Form/Settings.hlp
@@ -57,6 +57,7 @@
 {htxt id='id-diff-activity'}
   <p>{ts domain="de.systopia.xcm"}This feature enables you to track and process all submitted data when a contact has been identified - but not changed.{/ts}</p>
   <p>{ts domain="de.systopia.xcm"}The activity will contain an overview of the differing attributes for contact, and will be linked to that contact.{/ts}</p>
+  <p>{ts domain="de.systopia.xcm"}The handler Update and Difference activity will also record the updated changes. Whlist the Diff Activity will only record the differences and you have to apply the changes manually.{/ts}</p>
 {/htxt}
 
 {htxt id='id-override-details'}

--- a/templates/CRM/Xcm/Form/Settings.tpl
+++ b/templates/CRM/Xcm/Form/Settings.tpl
@@ -227,6 +227,12 @@
   </div>
 
   <div class="crm-section xcm-diff-common">
+    <div class="label">{$form.diff_activity_status.label}</div>
+    <div class="content">{$form.diff_activity_status.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section xcm-diff-common">
     <div class="label">{$form.diff_activity_subject.label}</div>
     <div class="content">{$form.diff_activity_subject.html}</div>
     <div class="clear"></div>

--- a/templates/CRM/Xcm/Form/Settings.tpl
+++ b/templates/CRM/Xcm/Form/Settings.tpl
@@ -292,7 +292,7 @@ cj("#diff_handler").change(function() {
   if (value == 'i3val') {
     cj("div.xcm-diff-common").show();
     cj("div.xcm-diff-diff-only").hide();
-  } else if (value == 'diff') {
+  } else if (value == 'diff' || value == 'updated_diff') {
     cj("div.xcm-diff-common").show();
     cj("div.xcm-diff-diff-only").show();
   } else {


### PR DESCRIPTION
When one sets a override field and/or override details. Then this data is not added to the diff activity.

Expected behaviour
The diff activity is created listing the old data and the submitted data
The submitted data is stored at the contact, overriding existing data.

Current behaviour
The data is overridden at the contact record but not listed in the diff activity.