### PR TITLE
Add match_only parameter

### DIFF
--- a/CRM/Xcm/MatchingEngine.php
+++ b/CRM/Xcm/MatchingEngine.php
@@ -72,13 +72,16 @@ class CRM_Xcm_MatchingEngine {
 
     if (empty($result['contact_id'])) {
       // the matching failed
-      $new_contact = $this->createContact($contact_data);
-      $result['contact_id'] = $new_contact['id'];
-      // TODO: add more data? how?
 
-      // do the post-processing
-      $this->postProcessNewContact($new_contact, $contact_data);
+      if (empty($contact_data['match_only'])) {
+        // Create contact (the "orcreate" bit), unless match_only was set.
+        $new_contact = $this->createContact($contact_data);
+        $result['contact_id'] = $new_contact['id'];
+        // TODO: add more data? how?
 
+        // do the post-processing
+        $this->postProcessNewContact($new_contact, $contact_data);
+      }
     } else {
       // the matching was successful
       $this->postProcessContactMatch($result, $contact_data);

--- a/api/v3/Contact/Getorcreate.php
+++ b/api/v3/Contact/Getorcreate.php
@@ -51,5 +51,12 @@ function _civicrm_api3_contact_getorcreate_spec(&$params) {
       'type'         => CRM_Utils_Type::T_STRING,
       'title'        => 'Which profile should be used for matching?',
   );
+  $params['match_only'] = [
+    'name' => 'match_only',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    'title' => 'Match only',
+    'api.default' => 0,
+    'description' => 'Either return the matched contact, or nothing; do not create a contact.'
+  ];
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,3 +53,14 @@ $result = civicrm_api3('Contact', 'getorcreate', array(
 ```
 
 They were found and no duplicate contact was created.
+
+## Special use case: `match_only` parameter
+
+The normal function is to get-or-create a contact. However there are times
+when you’d like to check before creating a contact; XCM is very handy for
+searching on a number of queries.
+
+Passing `match_only=1` will mean that if there is no match no contact will
+be created, and instead an error will be returned: "Unknown matching
+error.". However, if a match is found, all the normal processing will
+occur; so this is not a read-only operation.


### PR DESCRIPTION
Well, you're either going to love this or reject it outright!

I have often wanted to harness the power and configuration of XCM to see if we can find a contact, but if not, take some action other than creating a contact.

This PR adds a `match_only` parameter. See README diff for explanation.

Example use-case: I have names and three possible emails for a contact, and maybe an address. I want to use XCM to find the person given the first email, but if it fails, I want to try the other emails before giving up and creating a contact.