### PR TITLE
Add fill options for Phone and E-mail details

### DIFF
--- a/CRM/Xcm/Form/Settings.php
+++ b/CRM/Xcm/Form/Settings.php
@@ -152,8 +152,6 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
                       'fill_details',
                       E::ts('Fill Details'),
                       array(
-                        'email'   => E::ts('Email'),
-                        'phone'   => E::ts('Phone'),
                         'website' => E::ts('Website')),
                       array(// 'style'    => 'width:450px; height:100%;',
                             'multiple' => 'multiple',
@@ -170,6 +168,23 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
                             1 => E::ts('If contact has no address'),
                             2 => E::ts('If contact has no address of that type')),
                       array('class' => 'crm-select2 huge'));
+    $this->addElement('select',
+      'fill_email',
+      E::ts('Fill Email'),
+      array(0 => E::ts('Never'),
+        1 => E::ts('If contact has no email'),
+        2 => E::ts('If contact has no email of that type'),
+        3 => E::ts('If contact has not this email address')),
+      array('class' => 'crm-select2 huge'));
+
+    $this->addElement('select',
+      'fill_phone',
+      E::ts('Fill Phone'),
+      array(0 => E::ts('Never'),
+        1 => E::ts('If contact has no phone'),
+        2 => E::ts('If contact has no phone of that type'),
+        3 => E::ts('If contact has not this phone number')),
+      array('class' => 'crm-select2 huge'));
 
 
     // diff activity options
@@ -361,6 +376,8 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
     // store options
     $options = array(
       'fill_address'               => CRM_Utils_Array::value('fill_address', $values),
+      'fill_email'                 => CRM_Utils_Array::value('fill_email', $values),
+      'fill_phone'                 => CRM_Utils_Array::value('fill_phone', $values),
       'fill_fields_multivalue'     => CRM_Utils_Array::value('fill_fields_multivalue', $values),
       'fill_details'               => CRM_Utils_Array::value('fill_details', $values),
       'fill_details_primary'       => CRM_Utils_Array::value('fill_details_primary', $values),

--- a/CRM/Xcm/Upgrader.php
+++ b/CRM/Xcm/Upgrader.php
@@ -128,4 +128,36 @@ class CRM_Xcm_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Changing fill email and fill phone to If contact has no email of that type or no phone of that type
+   *
+   * @return TRUE on success
+   * @throws Exception
+   */
+  public function upgrade_0201() {
+    $this->ctx->log->info('Changing fill email and fill phone to If contact has no email of that type or no phone of that type.');
+    $allProfiles = CRM_Xcm_Configuration::getProfileList();
+    foreach ($allProfiles as $profileName => $profileLabel) {
+      $profile = CRM_Xcm_Configuration::getConfigProfile($profileName);
+      if ($profile instanceof CRM_Xcm_Configuration) {
+        $options = $profile->getOptions();
+        if ($options) {
+          // Backwards compatibility change fill details email to fill email.
+          if (empty($options['fill_email']) && ($key = array_search('email', $options['fill_details']))!==false) {
+            $options['fill_email'] = 3;
+            unset($options['fill_details'][$key]);
+          }
+          // Backwards compatibility change fill details phone to fill phone.
+          if (empty($options['fill_phone']) && ($key = array_search('phone', $options['fill_details']))!==false) {
+            $options['fill_phone'] = 3;
+            unset($options['fill_details'][$key]);
+          }
+          $profile->setOptions($options);
+          $profile->store();
+        }
+      }
+    }
+    return TRUE;
+  }
+
 }

--- a/templates/CRM/Xcm/Form/Settings.tpl
+++ b/templates/CRM/Xcm/Form/Settings.tpl
@@ -131,6 +131,18 @@
     <div class="clear"></div>
   </div>
 
+  <div class="crm-section">
+    <div class="label">{$form.fill_email.label}</div>
+    <div class="content">{$form.fill_email.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
+    <div class="label">{$form.fill_phone.label}</div>
+    <div class="content">{$form.fill_phone.html}</div>
+    <div class="clear"></div>
+  </div>
+
 </div>
 
 


### PR DESCRIPTION
With the fill details options I would expect that a phone number is added when no phone number with the location type and phone type exists.

When a phone number with that location type and phone type already exists I would expect that nothing changes. However the new phone number gets added and I end up with two phones of the same location type and phone type.

This PR enhances the settings for fill details for phone numbers. The same issue also exists with e-mail addresses and this PR also fixes it for the e-mail addresses. 

**Before**

Below a screenshot of the settings screen:

![Screenshot_20210716_111251](https://user-images.githubusercontent.com/4126292/125942879-42db6e0f-5872-497a-9089-daa02ffbe7bf.png)

**After**

Below a screenshot with the changes applied to the settings screen:

![Screenshot_20210716_111917](https://user-images.githubusercontent.com/4126292/125942921-bd657006-9f9a-4102-94a2-7e2a07eaa886.png)

And for e-mail 

![Screenshot_20210726_154510](https://user-images.githubusercontent.com/4126292/126999339-7d5f5b83-46a6-4116-9232-d1c0f4cf6740.png)


The changes are backwards compatible. Meaning that if someone had selected phone at the Fill details, the Fill Phone is set to `If contact has not this phone number`.


**Comment**

This PR also removes the phone_numeric field from the diff activity.  
