### PR TITLE
Support website types correctly

### DIFF
--- a/CRM/Xcm/Configuration.php
+++ b/CRM/Xcm/Configuration.php
@@ -369,6 +369,14 @@ class CRM_Xcm_Configuration {
     return (int) CRM_Utils_Array::value('secondary_phone_type', $options);
   }
 
+  /**
+   * Get default website type
+   */
+  public function defaultWebsiteType() {
+    $options = $this->getOptions();
+    return (int) CRM_Utils_Array::value('default_website_type', $options);
+  }
+
 
   /**
    * Get location type to be used for new addresses

--- a/CRM/Xcm/Form/Settings.php
+++ b/CRM/Xcm/Form/Settings.php
@@ -68,6 +68,7 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
 
     $locationTypes = $this->getLocationTypes();
     $phoneTypes = $this->getPhoneTypes();
+    $websiteTypes = $this->getWebsiteTypes();
 
     // add general options
     $this->addElement('select',
@@ -97,6 +98,12 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
                       $phoneTypes,
                       false,
                       array('class' => 'crm-select2 huge', 'placeholder' => E::ts('Secondary phone not used')));
+    $this->add('select',
+                      'default_website_type',
+                      E::ts('Default Website Type'),
+                      $websiteTypes,
+                      false,
+                      array('class' => 'crm-select2 huge'));
     $this->addElement('select',
                       'fill_fields',
                       E::ts('Fill Fields'),
@@ -351,6 +358,7 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
       'default_location_type'      => CRM_Utils_Array::value('default_location_type', $values),
       'primary_phone_type'         => CRM_Utils_Array::value('primary_phone_type', $values),
       'secondary_phone_type'       => CRM_Utils_Array::value('secondary_phone_type', $values),
+      'default_website_type'       => CRM_Utils_Array::value('default_website_type', $values),
       'picker'                     => CRM_Utils_Array::value('picker', $values),
       'input_sanitation'           => CRM_Utils_Array::value('input_sanitation', $values),
       'duplicates_activity'        => CRM_Utils_Array::value('duplicates_activity', $values),
@@ -432,6 +440,15 @@ class CRM_Xcm_Form_Settings extends CRM_Core_Form {
   protected function getPhoneTypes() {
     $types = array();
     $result = civicrm_api3('OptionValue', 'get', array('is_active' => 1, 'option_group_id' => 'phone_type', 'option.limit' => 0));
+    foreach ($result['values'] as $type) {
+      $types[$type['value']] = $type['label'];
+    }
+    return $types;
+  }
+
+  protected function getWebsiteTypes() {
+    $types = array();
+    $result = civicrm_api3('OptionValue', 'get', array('is_active' => 1, 'option_group_id' => 'website_type', 'option.limit' => 0));
     foreach ($result['values'] as $type) {
       $types[$type['value']] = $type['label'];
     }

--- a/CRM/Xcm/MatchingEngine.php
+++ b/CRM/Xcm/MatchingEngine.php
@@ -506,20 +506,21 @@ class CRM_Xcm_MatchingEngine {
    */
   protected function addDetailToContact($contact_id, $entity, &$data, $as_primary = FALSE, &$data_update = NULL) {
     if (!empty($data[$entity])) {
-      // sort out location type
-      if (empty($data['location_type_id'])) {
-        $location_type_id = $this->config->defaultLocationType();
-      } else {
-        $location_type_id = $data['location_type_id'];
-      }
-
-      // get attribute
-      $attribute = strtolower($entity); // for email and phone that works
-      $sorting = 'is_primary desc';
+      // Params for a possible "create" API call.
+      $create_detail_call['contact_id'] = $contact_id;
+      // sort out location/website type
       if (strtolower($entity) == 'website') {
-        $attribute = 'url';
+        $create_detail_call['website_type_id'] = $data['website_type_id'] ?? $this->config->defaultWebsiteType();
         $sorting = 'id desc';
+        $attribute = 'url';
       }
+      else {
+        $create_detail_call['location_type_id'] = $data['location_type_id'] ?? $this->config->defaultLocationType();
+        $sorting = 'is_primary desc';
+        // for email and phone this works
+        $attribute = strtolower($entity);
+      }
+      $create_detail_call[$attribute] = $data[$entity];
 
       // some value was submitted -> check if there is already an existing one
       $existing_entity = civicrm_api3($entity, 'get', array(
@@ -529,11 +530,6 @@ class CRM_Xcm_MatchingEngine {
         'option.limit' => 1));
       if (empty($existing_entity['count'])) {
         // there is none -> create
-        $create_detail_call = array(
-          $attribute         => $data[$entity],
-          'contact_id'       => $contact_id,
-          'location_type_id' => $location_type_id);
-
         // mark as primary if requested
         if ($as_primary) {
           $create_detail_call['is_primary'] = 1;

--- a/CRM/Xcm/Tools.php
+++ b/CRM/Xcm/Tools.php
@@ -39,7 +39,7 @@ class CRM_Xcm_Tools {
    * return all contact detail fields
    */
   public static function getDetailFields() {
-    return ['email', 'url', 'phone'];
+    return ['email', 'url', 'phone', 'website'];
   }
 
   /**

--- a/templates/CRM/Xcm/Form/Settings.hlp
+++ b/templates/CRM/Xcm/Form/Settings.hlp
@@ -45,7 +45,11 @@
 
 {htxt id='id-location-type'}
   <p>{ts domain="de.systopia.xcm"}If no location type is explicitly submitted, this location type will be assumed.{/ts}</p>
-  <p>{ts domain="de.systopia.xcm"}The location type is used for newly created addresses, emails, phones, and websites.{/ts}</p>
+  <p>{ts domain="de.systopia.xcm"}The location type is used for newly created addresses, emails, and phones.{/ts}</p>
+{/htxt}
+
+{htxt id='id-website-type'}
+  <p>{ts domain="de.systopia.xcm"}If no website type is explicitly submitted, this website type will be assumed.{/ts}</p>
 {/htxt}
 
 {htxt id='id-phone-type'}

--- a/templates/CRM/Xcm/Form/Settings.tpl
+++ b/templates/CRM/Xcm/Form/Settings.tpl
@@ -66,6 +66,12 @@
     <div class="clear"></div>
   </div>
 
+  <div class="crm-section">
+    <div class="label">{$form.default_website_type.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.xcm"}Default Website Type{/ts}", {literal}{"id":"id-website-type","file":"CRM\/Xcm\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.xcm"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+    <div class="content">{$form.default_website_type.html}</div>
+    <div class="clear"></div>
+  </div>
+
 </div>
 
 <div>


### PR DESCRIPTION
I received a report that all websites were importing with the type "Work" regardless of whether that was the type specified.  This was because "location type id" was being used where "website type id" was intended.

I fixed this, and added support for specifying a default website type in order to maintain parity with location type.