### PR TITLE
don't create empty addresses

### DIFF
--- a/CRM/Xcm/Tools.php
+++ b/CRM/Xcm/Tools.php
@@ -122,7 +122,7 @@ class CRM_Xcm_Tools {
       }
     }
 
-    if ($copy_location_type && isset($data['location_type_id'])) {
+    if ($copy_location_type && isset($data['location_type_id']) && !empty($address_data)) {
       $address_data['location_type_id'] = $data['location_type_id'];
     }
     return $address_data;


### PR DESCRIPTION
If the location type is added to a by then empty `$address_data` array, the array will be used later to create an address because `!empty($address_data)` returns `false`.

Fix #93