### PR TITLE
Add managed entities for "automation" and "configure_xcm" navigation menu items

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -29,6 +29,7 @@
     <format>22.05.2</format>
   </civix>
   <mixins>
+    <mixin>mgd-php@1.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
   </mixins>

--- a/managed/Navigation__configure_xcm.mgd.php
+++ b/managed/Navigation__configure_xcm.mgd.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use CRM_Xcm_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'Navigation__automation',
+    'entity' => 'Navigation',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'domain_id' => 'current_domain',
+        'label' => E::ts('Automation'),
+        'name' => 'automation',
+        'url' => NULL,
+        'icon' => NULL,
+        'permission' => [
+          'administer CiviCRM',
+        ],
+        'permission_operator' => 'OR',
+        'parent_id.name' => 'Administer',
+        'is_active' => TRUE,
+        'has_separator' => 0,
+      ],
+      'match' => ['name', 'parent_id'],
+    ],
+  ],
+  [
+    'name' => 'Navigation__configure_xcm',
+    'entity' => 'Navigation',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'domain_id' => 'current_domain',
+        'label' => E::ts('Extended Contact Matcher (XCM)'),
+        'name' => 'configure_xcm',
+        'url' => 'civicrm/admin/setting/xcm',
+        'icon' => NULL,
+        'permission' => [
+          'administer CiviCRM',
+        ],
+        'permission_operator' => 'OR',
+        'parent_id.name' => 'automation',
+        'is_active' => TRUE,
+        'has_separator' => 0,
+      ],
+      'match' => ['name', 'parent_id'],
+    ],
+  ],
+];

--- a/xcm.php
+++ b/xcm.php
@@ -147,24 +147,8 @@ function xcm_civicrm_navigationMenu(&$menu) {
     'weight' => $menu_items['weight'] + 1,
   ]);
 
-  // ADD configure XCM to automation tab
-  if (!_xcm_menu_exists($menu, 'Administer/automation')) {
-    _xcm_civix_insert_navigation_menu($menu, 'Administer', [
-        'label' => E::ts('Automation'),
-        'name' => 'automation',
-        'url' => NULL,
-        'permission' => 'administer CiviCRM',
-        'operator' => NULL,
-        'separator' => 0,
-    ]);
-  }
-  _xcm_civix_insert_navigation_menu($menu, 'Administer/automation', [
-      'label' => E::ts('Extended Contact Matcher (XCM)'),
-      'name' => 'configure_xcm',
-      'url' => 'civicrm/admin/setting/xcm',
-      'permission' => 'administer CiviCRM',
-      'operator' => NULL,
-  ]);
+  // Note: "Configure XCM" in "Automation" sub-menu is being taken care of by
+  // managed entities, see /managed/Navigation__configure_xcm.mgd.php.
   _xcm_civix_navigationMenu($menu);
 }
 


### PR DESCRIPTION
The menu item with the link to the XCM configuration form is inside a sub-menu called *Automation* which is being used by other extensions as well (e. g. systopia/de.systopia.sqltasks, systopia/hiorg), the latter of which uses *Managed Entities* for adding the menu item, trying to match existing entries by `name` and `parent_id`, which apparently does not work in tandem with the old-style hook implementations via `hook_civicrm_navigationMenu()`. Currently, this results in each definition of the *automation* menu item creating a new one, duplicating it in the menu.

Defining all of those through *Managed Entities* seems to resolve this issue.

I'm thus adding the configuration menu item and its parent *Automation* menu item as managed entities, removing their definition from the hook implementation.