### PR TITLE
Improve Name Extraction in Banking Matcher Plugin

### DIFF
--- a/CRM/Banking/PluginImpl/Matcher/GetOrCreateContactAnalyser.php
+++ b/CRM/Banking/PluginImpl/Matcher/GetOrCreateContactAnalyser.php
@@ -267,13 +267,21 @@ class CRM_Banking_PluginImpl_Matcher_GetOrCreateContactAnalyser extends CRM_Bank
         foreach ($name_bits as $name_bit) {
           if (!$this->isNameBlacklisted($name_bit, $config->name_blacklist)) {
             if ((!$this->isNameBlacklisted($name_bit, $config->first_name_blacklist))
-                && $this->isDBFirstName($name_bit)) {
-              $first_names[] = $name_bit;
+                 && $this->isDBFirstName($name_bit)
+                 && empty($last_names)) {
+                 $first_names[] = $name_bit;
             } else {
               $last_names[] = $name_bit;
             }
           }
         }
+
+        // If we didn't find any last names, but we found more than one first name,
+        // then we assume that the last one is the last name of the contact
+        if (empty($last_names) && count($first_names) > 1) {
+            $last_names[] = array_pop($first_names);
+        }
+
         $this->logMessage("Identified (by DB) first names of '{$btx_name}' are: " . implode(',', $first_names), 'debug');
         $xcm_values['first_name'] = implode(' ', $first_names);
         $xcm_values['last_name'] = implode(' ', $last_names);

--- a/CRM/Banking/PluginImpl/Matcher/GetOrCreateContactAnalyser.php
+++ b/CRM/Banking/PluginImpl/Matcher/GetOrCreateContactAnalyser.php
@@ -267,21 +267,13 @@ class CRM_Banking_PluginImpl_Matcher_GetOrCreateContactAnalyser extends CRM_Bank
         foreach ($name_bits as $name_bit) {
           if (!$this->isNameBlacklisted($name_bit, $config->name_blacklist)) {
             if ((!$this->isNameBlacklisted($name_bit, $config->first_name_blacklist))
-                 && $this->isDBFirstName($name_bit)
-                 && empty($last_names)) {
-                 $first_names[] = $name_bit;
+                && $this->isDBFirstName($name_bit)) {
+              $first_names[] = $name_bit;
             } else {
               $last_names[] = $name_bit;
             }
           }
         }
-
-        // If we didn't find any last names, but we found more than one first name,
-        // then we assume that the last one is the last name of the contact
-        if (empty($last_names) && count($first_names) > 1) {
-            $last_names[] = array_pop($first_names);
-        }
-
         $this->logMessage("Identified (by DB) first names of '{$btx_name}' are: " . implode(',', $first_names), 'debug');
         $xcm_values['first_name'] = implode(' ', $first_names);
         $xcm_values['last_name'] = implode(' ', $last_names);

--- a/CRM/Banking/PluginImpl/Matcher/GetOrCreateContactAnalyser.php
+++ b/CRM/Banking/PluginImpl/Matcher/GetOrCreateContactAnalyser.php
@@ -279,6 +279,33 @@ class CRM_Banking_PluginImpl_Matcher_GetOrCreateContactAnalyser extends CRM_Bank
         $xcm_values['last_name'] = implode(' ', $last_names);
         break;
 
+      // See PR #112
+      case 'db2':
+        $first_names = [];
+        $last_names = [];
+        foreach ($name_bits as $name_bit) {
+            if (!$this->isNameBlacklisted($name_bit, $config->name_blacklist)) {
+                if ((!$this->isNameBlacklisted($name_bit, $config->first_name_blacklist))
+                    && $this->isDBFirstName($name_bit)
+                    && empty($last_names)) {
+                    $first_names[] = $name_bit;
+                } else {
+                    $last_names[] = $name_bit;
+                }
+            }
+        }
+
+        // If we didn't find any last names, but we found more than one first name,
+        // then we assume that the last one is the last name of the contact
+        if (empty($last_names) && count($first_names) > 1) {
+            $last_names[] = array_pop($first_names);
+        }
+
+        $this->logMessage("Identified (by DB) first names of '{$btx_name}' are: " . implode(',', $first_names), 'debug');
+        $xcm_values['first_name'] = implode(' ', $first_names);
+        $xcm_values['last_name'] = implode(' ', $last_names);
+        break;
+
       default:
       case 'off':
         break;


### PR DESCRIPTION
This commit improves the name extraction for the db mode.

- if there is more than one valid name bit, the last bit will always be the last name
- name bits following the first bit recognised as a last name will not become first names again


# Comparison of the results

```php
/**
 * Dummy function
 */
private function isDBFirstName($name_bit) {
  $fistnames = ['John', 'Jane', 'Alice', 'Bob', 'Arthur'];
  return in_array($name_bit, $fistnames);
}
```

## Original function
```
Name: John Doe, First names: John, Last names: Doe
Name: Jane Alice Doe, First names: Jane Alice, Last names: Doe
Name: Arthur Smith, First names: Arthur, Last names: Smith
Name: Alice Jane Arthur, First names: Alice Jane Arthur, Last names: 
Name: Bob King Arthur, First names: Bob Arthur, Last names: King
```

## Modified function
```
Name: John Doe, First names: John, Last names: Doe
Name: Jane Alice Doe, First names: Jane Alice, Last names: Doe
Name: Arthur Smith, First names: Arthur, Last names: Smith
Name: Alice Jane Arthur, First names: Alice Jane, Last names: Arthur
Name: Bob King Arthur, First names: Bob, Last names: King Arthur
```