### PR TITLE
Add missing quotation marks to avoid error in Smarty > v2

### DIFF
--- a/templates/activity/diff.tpl
+++ b/templates/activity/diff.tpl
@@ -11,12 +11,12 @@
 | copyright header is strictly prohibited without        |
 | written permission from the original author(s).        |
 +-------------------------------------------------------*}
-<h3>{ts 1=$existing_contact.display_name domain=de.systopia.xcm}Differing attributes for contact "%1" submitted{/ts}</h3>
+<h3>{ts 1=$existing_contact.display_name domain="de.systopia.xcm"}Differing attributes for contact "%1" submitted{/ts}</h3>
 <table>
   <thead>
-    <th>{ts domain=de.systopia.xcm}Attribute{/ts}</th>
-    <th>{ts domain=de.systopia.xcm}Recorded Value{/ts}</th>
-    <th>{ts domain=de.systopia.xcm}Submitted Value{/ts}</th>
+    <th>{ts domain="de.systopia.xcm"}Attribute{/ts}</th>
+    <th>{ts domain="de.systopia.xcm"}Recorded Value{/ts}</th>
+    <th>{ts domain="de.systopia.xcm"}Submitted Value{/ts}</th>
   </thead>
 
   <tbody>


### PR DESCRIPTION
Smarty > v2 needs quotes around attributes (from the Smarty docs: 'Static values don't have to be enclosed in quotes, but it is required for literal strings'). After we upgraded our CiviCRM installation from Smarty 2 to Smarty 4, we got an error in this template which is fixed by this commit.