### PR TITLE
Fix for #121: Added functionality when Address Parsing is enabled

### DIFF
--- a/CRM/Xcm/Tools.php
+++ b/CRM/Xcm/Tools.php
@@ -29,10 +29,20 @@ class CRM_Xcm_Tools {
    * return all address fields
    */
   public static function getAddressFields() {
-    return array(
+    $addressOptions = \CRM_Core_BAO_Setting::valueOptions(\CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'address_options');
+    $isStreetAddressParsingEnabled = !empty($addressOptions['street_address_parsing']);
+
+    $addressFields = array(
       'supplemental_address_1', 'supplemental_address_2', 'supplemental_address_3',
       'street_address', 'city', 'country_id', 'state_province_id', 'county_id', 'postal_code',
       'is_billing', 'geo_code_1', 'geo_code_2');
+    if ($isStreetAddressParsingEnabled) {
+      $addressFields[] = 'street_name';
+      $addressFields[] = 'street_number';
+      $addressFields[] = 'street_number_suffix';
+      $addressFields[] = 'street_unit';
+    }
+    return $addressFields;
   }
 
   /**
@@ -77,6 +87,10 @@ class CRM_Xcm_Tools {
         'suffix_id' => ts('Suffix'),
         'email' => ts('Email'),
         'street_address' => ts('Street Address'),
+        'street_name' => ts('Street Name'),
+        'street_number' => ts('Street Number'),
+        'street_number_suffix' => ts('Street Number Suffix'),
+        'street_unit' => ts('Street Unit'),
         'city' => ts('City'),
         'country_id' => ts('Country'),
         'state_province_id' => ts('State/Province'),


### PR DESCRIPTION
When address parsing is enabled CiviCRM gives the ability to enter the individual street address fields (street name, street number, street number suffix and street unit). 

This PR adds those fields to XCM when Street Parsing is enabled. 

Tested scenario's

**Street address parsing disabled**

Street address: Sterkerij 9B Bus 2

Matched on street address (and this field shows up in a diff activity when the field is different)

**Street address parsing enabled (1)**

Street address: Sterkerij 9B Bus 2

Matched on street address (and this field shows up in a diff activity when the field is different)

**Street address parsing enabled (2)**

Street name: Sterkerij
Street number: 9B
Street unit: Bus 2

Matched on Street name, Street number, Street number suffix, and Street unit (and those fields show up in a diff activity when the fields are different).