### PR TITLE
#109 Fix for i3val activity type change

### DIFF
--- a/CRM/Xcm/MatchingEngine.php
+++ b/CRM/Xcm/MatchingEngine.php
@@ -1082,6 +1082,7 @@ class CRM_Xcm_MatchingEngine {
     // compile udpate request
     $submitted_contact_data['id'] = $current_contact_data['id'];
     $submitted_contact_data['activity_subject'] = $options['diff_activity_subject'];
+    $submitted_contact_data['activity_type_id'] = $options['diff_activity'];
 
     try {
       $result = civicrm_api3('Contact', 'request_update', $submitted_contact_data);


### PR DESCRIPTION
> When I want to change the ActivityType for the DiffernceHandling in the XCM-Profile UI, because I switched the "Process Differences"-Option from "DiffActivity" to "I3Val Handler", I expect the next created Activity for that purpose to of the selected activityType. But it falls back to the initially selected activityType, resulting in activityType not switchable.
> ### steps to reproduce
> 
>     1. installed versions:
>        
>        1. XCM 1.11.0,
>        2. I3Val Input Validation 0.5-alpha13
>        3. CiviCRM 5.58.1
> 
>     2. create XCM-Profile with initial DifferenceHandling
> 
>     3. edit this profile -> DifferenceHandling -> Process Differences: I3Val Handler and switch activityType to any other
> 
>     4. use Profile via API (contact.getorcreate) -> activityType of the newly created DifferenceActivity is still the same as before
> 
>     5. switch back to ProcessDifferences: "Diff Activity" in the profile and keep the newly created ActivityType: test again -> new activityType is used

See #109 