### PR TITLE
Update call to deprecated Smarty::get_template_vars

### DIFF
--- a/CRM/Xcm/MatchingEngine.php
+++ b/CRM/Xcm/MatchingEngine.php
@@ -1290,7 +1290,7 @@ class CRM_Xcm_MatchingEngine {
     $smarty = CRM_Core_Smarty::singleton();
 
     // first backup original variables, since smarty instance is a singleton
-    $oldVars = $smarty->get_template_vars();
+    $oldVars = $smarty->getTemplateVars();
     $backupFrame = array();
     foreach ($vars as $key => $value) {
       $key = str_replace(' ', '_', $key);


### PR DESCRIPTION
Replaces deprecated function name with the forward-compat equivalent.

Note: the new getTemplateVars function has been available since CiviCRM 5.70.