### PR TITLE
fix: warning about missing 'is_default' key

### DIFF
--- a/CRM/Xcm/Configuration.php
+++ b/CRM/Xcm/Configuration.php
@@ -227,7 +227,7 @@ class CRM_Xcm_Configuration {
    */
   public function isDefault(): int {
     $profile_data = $this->getConfiguration();
-    return isset($profile_data['is_default']) ? (int) $profile_data['is_default'] : 0;
+    return (int) ($profile_data['is_default'] ?? 0);
   }
 
   /**

--- a/CRM/Xcm/Configuration.php
+++ b/CRM/Xcm/Configuration.php
@@ -227,7 +227,7 @@ class CRM_Xcm_Configuration {
    */
   public function isDefault(): int {
     $profile_data = $this->getConfiguration();
-    return (int) $profile_data['is_default'] ?? 0;
+    return isset($profile_data['is_default']) ? (int) $profile_data['is_default'] : 0;
   }
 
   /**


### PR DESCRIPTION
The statement printed a warning (if output enabled) in the admin GUI.