### PR TITLE
Fix for issue class 25 not found.

### DIFF
--- a/CRM/Xcm/Matcher/DedupeRule.php
+++ b/CRM/Xcm/Matcher/DedupeRule.php
@@ -75,7 +75,7 @@ class CRM_Xcm_Matcher_DedupeRule extends CRM_Xcm_MatchingRule {
       ->execute();
     $list = [];
     foreach ($dedupeRuleGroups as $dedupeRuleGroup) {
-      $list[$dedupeRuleGroup['id']]
+      $list['DEDUPE_' . $dedupeRuleGroup['id']]
         = "[{$dedupeRuleGroup['contact_type']}|{$dedupeRuleGroup['used']}] {$dedupeRuleGroup['title']}";
     }
     return $list;

--- a/CRM/Xcm/Matcher/DedupeRule.php
+++ b/CRM/Xcm/Matcher/DedupeRule.php
@@ -65,7 +65,7 @@ class CRM_Xcm_Matcher_DedupeRule extends CRM_Xcm_MatchingRule {
   }
 
   /**
-   * @return array<int, string>
+   * @return array<string, string>
    *   A key => title list of existing unsupervised dedupe rules.
    */
   public static function getRuleList(): array {

--- a/CRM/Xcm/MatchingEngine.php
+++ b/CRM/Xcm/MatchingEngine.php
@@ -263,7 +263,7 @@ class CRM_Xcm_MatchingEngine {
       }
       elseif ('DEDUPE_' == substr($rule_name, 0, 7)) {
         // this is a dedupe rule
-        $new_rule = new CRM_Xcm_Matcher_DedupeRule(substr($rule_name, 7));
+        $new_rule = new CRM_Xcm_Matcher_DedupeRule((int) substr($rule_name, 7));
         $new_rule->setConfig($this->config);
         $rule_instances[] = $new_rule;
 


### PR DESCRIPTION
After upgrading XCM and resaving all the profiles we get an error *Class "25" not found*

This is caused in https://github.com/systopia/de.systopia.xcm/blob/master/CRM/Xcm/Matcher/DedupeRule.php#L78 by commit: 300091cad9b47fb41272b49e22dbeb22dab0fc54

In that commit the prefix for `DEDUPE_` is gone missing from the dedupe rule list. 

See #138 